### PR TITLE
fix: ci trigger on master branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
     tags:
+      - '**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Description
CI is not triggering on master branch when pushing tags. This pull request fixes that wrong behaviour.