### PR TITLE
fix: change docker pwd environment variables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,5 +27,5 @@ jobs:
         run: make docker.push
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           DOCKER_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
## Description
Change `DOCKER_HUB_PASSWORD` environment variable to `DOCKER_PASSWORD` since the expected variable is `DOCKER_PASSWORD`.